### PR TITLE
Fix validate mnemonic and use ZdkException for CheckAndSetFields errors

### DIFF
--- a/src/Zenon/Utils/BlockUtils.cs
+++ b/src/Zenon/Utils/BlockUtils.cs
@@ -113,29 +113,29 @@ namespace Zenon.Utils
             {
                 if (transaction.FromBlockHash == Hash.Empty)
                 {
-                    throw new Exception();
+                    throw new ZdkException("From block hash is empty");
                 }
 
                 var sendBlock = await zdk.Ledger.GetAccountBlockByHash(transaction.FromBlockHash);
 
                 if (sendBlock == null)
                 {
-                    throw new Exception();
+                    throw new ZdkException("From block does not exist");
                 }
                 if (sendBlock.ToAddress.ToString() != transaction.Address.ToString())
                 {
-                    throw new Exception();
+                    throw new ZdkException("To address does not match");
                 }
 
                 if (transaction.Data == null || transaction.Data.Length != 0)
                 {
-                    throw new Exception();
+                    throw new ZdkException("Data must be empty");
                 }
             }
 
             if (transaction.Difficulty > 0 && transaction.Nonce == "")
             {
-                throw new Exception();
+                throw new ZdkException("Empty nonce");
             }
 
             return true;

--- a/src/Zenon/Wallet/Mnemonic.cs
+++ b/src/Zenon/Wallet/Mnemonic.cs
@@ -12,7 +12,7 @@ namespace Zenon.Wallet
 
         public static bool ValidateMnemonic(params string[] words)
         {
-            return new BIP39.BIP39().ValidateMnemonic(String.Concat(" ", words), BIP39Wordlist.English);
+            return new BIP39.BIP39().ValidateMnemonic(String.Join(" ", words), BIP39Wordlist.English);
         }
 
         public static bool IsValidWord(string word)


### PR DESCRIPTION
This PR fixes the `ValidateMnemonic` method and uses `ZdkException` for CheckAndSetFields errors.