### PR TITLE
Fix KeyNotFoundException when reading keyStore without the walletType metadata

### DIFF
--- a/src/Zenon/Wallet/KeyStoreManager.cs
+++ b/src/Zenon/Wallet/KeyStoreManager.cs
@@ -47,7 +47,7 @@ namespace Zenon.Wallet
             var content = File.ReadAllText(keyStorePath);
             var file = new EncryptedFile(JEncryptedFile.FromJObject(JObject.Parse(content)));
             if (file.Metadata != null &&
-                file.Metadata![Constants.WalletTypeKey] != null &&
+                file.Metadata!.ContainsKey(Constants.WalletTypeKey) &&
                 file.Metadata![Constants.WalletTypeKey] != Constants.KeyStoreWalletType)
             {
                 throw new WalletException($"Wallet type ({file.Metadata[Constants.WalletTypeKey]}) is not supported");


### PR DESCRIPTION
This PR fixes the `KeyNotFoundException` when reading a `keyStore` without the `walletType` key in the metadata dictionary.

The following `if` statement throws an exception when trying to retrieve the key value if it is not present.
``` csharp
if (file.Metadata != null &&
    file.Metadata![Constants.WalletTypeKey] != null &&
    file.Metadata![Constants.WalletTypeKey] != Constants.KeyStoreWalletType)
{
    throw new WalletException($"Wallet type ({file.Metadata[Constants.WalletTypeKey]}) is not supported");
}
```

The `ContainsKey` method needs to be used to check whether the key is present or not.

``` csharp
file.Metadata!.ContainsKey(Constants.WalletTypeKey)
```